### PR TITLE
fix: preview pipeline should not deploy GitHub Pages (#78)

### DIFF
--- a/.github/workflows/squad-docs.yml
+++ b/.github/workflows/squad-docs.yml
@@ -3,7 +3,7 @@ name: Squad Docs — Build & Deploy
 on:
   workflow_dispatch:
   push:
-    branches: [preview]
+    branches: [main]
     paths:
       - 'docs/**'
       - '.github/workflows/squad-docs.yml'


### PR DESCRIPTION
Fixes #78

Remove preview branch trigger from squad-docs.yml deploy workflow. The preview branch is for validation only — GitHub Pages should only deploy from the production branch.