### PR TITLE
feat: Package skill tools into release and install skill dependencies (#75)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -26,7 +26,24 @@ try {
     exit 1
 }
 
-Write-Host ""
+# Install skill dependencies if present
+if (Test-Path "skill\requirements.txt") {
+    Write-Host "🧠 Installing skill dependencies..." -ForegroundColor Cyan
+    try {
+        if (Get-Command pip -ErrorAction SilentlyContinue) {
+            pip install -r skill\requirements.txt
+            Write-Host "  ✓ Skill dependencies installed" -ForegroundColor Green
+        } elseif (Get-Command pip3 -ErrorAction SilentlyContinue) {
+            pip3 install -r skill\requirements.txt
+            Write-Host "  ✓ Skill dependencies installed" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host "  ❌ Failed to install skill dependencies: $_" -ForegroundColor Red
+        exit 1
+    }
+    Write-Host ""
+}
+
 Write-Host "✅ Installation complete!" -ForegroundColor Green
 Write-Host ""
 Write-Host "Usage:" -ForegroundColor Cyan

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,19 @@ else
     exit 1
 fi
 
-echo ""
+# Install skill dependencies if present
+if [ -f "skill/requirements.txt" ]; then
+    echo "🧠 Installing skill dependencies..."
+    if command -v pip &> /dev/null; then
+        pip install -r skill/requirements.txt
+        echo "  ✓ Skill dependencies installed"
+    elif command -v pip3 &> /dev/null; then
+        pip3 install -r skill/requirements.txt
+        echo "  ✓ Skill dependencies installed"
+    fi
+    echo ""
+fi
+
 echo "✅ Installation complete!"
 echo ""
 echo "Usage:"

--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -33,7 +33,7 @@ def create_release_package():
     ]
     
     # Directories to include
-    include_dirs = ["docs"]
+    include_dirs = ["docs", "skill"]
     
     repo_root = Path(__file__).parent.parent
     


### PR DESCRIPTION
## Summary

Fixes #75 — adds skill tools to the release package and ensures skill dependencies are installed.

## Changes

- **scripts/package_release.py** — Added skill/ to include_dirs so the full skill directory is bundled into the release ZIP alongside docs/.
- **install.sh** — After main Python deps, checks for skill/requirements.txt and installs it with pip/pip3 if present.
- **install.ps1** — Same logic for Windows: checks for skill\requirements.txt and installs it.

## Behavior

On a single-device install (mr-pumpkin + skills together), both equirements.txt and skill/requirements.txt are installed. On a device where only skill/ is deployed, the check gracefully skips if the file isn't present. No complex conditional logic needed — the Test-Path / [ -f ] check handles the dual-device scenario naturally.