### PR TITLE
feat: export/import recordings (#88)

### DIFF
--- a/client_example.py
+++ b/client_example.py
@@ -31,8 +31,12 @@ Usage:
       - timeline_status: Show playback state (state, filename, position, duration)
     Or file upload:
       - upload_timeline <filename> <json_file>: Upload a recording file
+    Or export/import:
+      - export_recordings <output_zip>: Export all recordings to a local zip file
+      - import_recordings <zip_file>: Import recordings from a local zip file
 """
 
+import base64
 import socket
 import json
 import os
@@ -138,6 +142,93 @@ def upload_timeline(filename: str, json_file_path: str):
     except Exception as e:
         print(f"Error uploading timeline: {e}")
 
+def export_recordings(output_zip_path: str):
+    """Export all recordings and audio files from the server as a zip.
+
+    Args:
+        output_zip_path: Local file path where the downloaded zip will be saved
+    """
+    try:
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client.connect(('localhost', 5000))
+        client.send(b'export_recordings')
+        client.shutdown(socket.SHUT_WR)
+
+        # Response may be large — read until connection closes
+        chunks = []
+        while True:
+            chunk = client.recv(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        client.close()
+
+        response = b''.join(chunks).decode('utf-8').strip()
+        if response.startswith("ERROR"):
+            print(f"Error: {response}")
+            return
+
+        if not response.startswith("RECORDINGS_ZIP:"):
+            print(f"Unexpected response: {response[:100]}")
+            return
+
+        zip_b64 = response[len("RECORDINGS_ZIP:"):]
+        zip_bytes = base64.b64decode(zip_b64)
+
+        with open(output_zip_path, 'wb') as f:
+            f.write(zip_bytes)
+
+        print(f"Exported recordings to: {output_zip_path} ({len(zip_bytes)} bytes)")
+    except Exception as e:
+        print(f"Error exporting recordings: {e}")
+
+def import_recordings(zip_file_path: str):
+    """Import recordings and audio files from a local zip to the server.
+
+    Existing files on the server are overwritten.
+
+    Args:
+        zip_file_path: Local path to the zip file to upload
+    """
+    if not os.path.exists(zip_file_path):
+        print(f"Error: File not found: {zip_file_path}")
+        return
+
+    try:
+        with open(zip_file_path, 'rb') as f:
+            zip_bytes = f.read()
+
+        zip_b64 = base64.b64encode(zip_bytes).decode('ascii')
+
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client.connect(('localhost', 5000))
+
+        # Send import command
+        client.send(b'import_recordings\n')
+
+        # Wait for READY signal
+        response = client.recv(1024).decode('utf-8').strip()
+        if response != "READY":
+            print(f"Error: Server did not send READY signal. Got: {response}")
+            client.close()
+            return
+
+        # Send base64-encoded zip data
+        client.send(zip_b64.encode('ascii'))
+        client.send(b"\n")
+
+        # Send end marker
+        client.send(b"END_UPLOAD\n")
+
+        # Get response
+        response = client.recv(1024).decode('utf-8').strip()
+        client.close()
+
+        print(f"Response: {response}")
+    except Exception as e:
+        print(f"Error importing recordings: {e}")
+
+
 if __name__ == "__main__":
     print("Pumpkin Face Client")
     print("Valid expressions: neutral, happy, sad, angry, surprised, scared, sleeping")
@@ -166,6 +257,9 @@ if __name__ == "__main__":
     print("  timeline_status - Show playback state")
     print("File upload:")
     print("  upload_timeline <server_filename> <local_json_file> - Upload a recording file")
+    print("Export/import:")
+    print("  export_recordings <output_zip> - Export all recordings to a local zip file")
+    print("  import_recordings <zip_file> - Import recordings from a local zip file")
     print("Type 'quit' to exit\n")
     
     while True:
@@ -183,5 +277,19 @@ if __name__ == "__main__":
                     print("Error: upload_timeline requires two arguments: server_filename local_json_file")
                 else:
                     upload_timeline(parts[1], parts[2])
+            # Handle export_recordings <output_zip>
+            elif user_input.startswith("export_recordings "):
+                parts = user_input.split(maxsplit=1)
+                if len(parts) < 2:
+                    print("Error: export_recordings requires one argument: output_zip_path")
+                else:
+                    export_recordings(parts[1])
+            # Handle import_recordings <zip_file>
+            elif user_input.startswith("import_recordings "):
+                parts = user_input.split(maxsplit=1)
+                if len(parts) < 2:
+                    print("Error: import_recordings requires one argument: zip_file_path")
+                else:
+                    import_recordings(parts[1])
             else:
                 send_command(user_input)

--- a/command_handler.py
+++ b/command_handler.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import time
 
@@ -579,6 +580,8 @@ class CommandRouter:
                 "  download_timeline <filename>       - Download timeline file as JSON content\n"
                 "  upload_timeline <filename>         - Upload a timeline file (enters upload mode)\n"
                 "  upload_audio <filename>            - Upload an audio file (enters upload mode)\n"
+                "  export_recordings                  - Export all recordings and audio files as a zip (base64)\n"
+                "  import_recordings                  - Import recordings zip (enters upload mode)\n"
                 "  neutral                            - Set expression to neutral\n"
                 "  happy                              - Set expression to happy\n"
                 "  sad                                - Set expression to sad\n"
@@ -721,14 +724,32 @@ class CommandRouter:
             # Note: upload_timeline requires socket-specific multi-step protocol
             # Return special marker to signal socket handler to enter upload mode
             return "UPLOAD_MODE"
-        
+
+        if data == "export_recordings":
+            try:
+                zip_bytes = self.pumpkin.file_manager.export_recordings()
+                zip_b64 = base64.b64encode(zip_bytes).decode('ascii')
+                response = f"RECORDINGS_ZIP:{zip_b64}"
+                print(f"Exported recordings ({len(zip_bytes)} bytes)")
+            except Exception as e:
+                response = f"ERROR {e}"
+                print(response)
+            return response
+
+        if data == "import_recordings":
+            # TCP import requires a multi-step protocol handled in pumpkin_face.py.
+            # This path is reached only for WebSocket (inline base64) — the TCP
+            # socket handler intercepts "import_recordings" before CommandRouter.
+            return "IMPORT_RECORDINGS_MODE"
+
         # ===== END TIMELINE COMMANDS =====
         
         # Check for manual override during playback
         # Timeline commands don't trigger pause, but animation/expression commands do
         is_timeline_command = data in ["record_start", "record start", "record_cancel", "record cancel", 
                                        "pause", "resume", "stop", "timeline_status", 
-                                       "recording_status", "list_recordings", "list"] or \
+                                       "recording_status", "list_recordings", "list",
+                                       "export_recordings", "import_recordings"] or \
                              data.startswith(("record_stop", "record stop", "play ", "seek ", 
                                              "delete_recording ", "rename_recording ", "upload_timeline ", "download_timeline "))
         

--- a/pumpkin_face.py
+++ b/pumpkin_face.py
@@ -1526,8 +1526,8 @@ class PumpkinFace:
                         if not data:
                             break
                         
-                        # Route commands through CommandRouter (except upload_timeline and upload_audio)
-                        if not (data.lower().startswith("upload_timeline ") or data.lower().startswith("upload_audio ")):
+                        # Route commands through CommandRouter (except upload_timeline, upload_audio, and import_recordings)
+                        if not (data.lower().startswith("upload_timeline ") or data.lower().startswith("upload_audio ") or data.lower() == "import_recordings"):
                             response = self.command_router.execute(data)
                             if response:  # Only send response if non-empty
                                 client_socket.sendall((response + '\n').encode('utf-8'))
@@ -1652,6 +1652,48 @@ class PumpkinFace:
                                 client_socket.sendall((response + '\n').encode('utf-8'))
                             continue
                         
+                        if data.lower() == "import_recordings":
+                            try:
+                                import base64
+                                # Signal ready for base64-encoded zip data
+                                client_socket.sendall(b"READY\n")
+
+                                # Read base64 content lines until END_UPLOAD marker
+                                b64_lines = []
+                                upload_done = False
+                                upload_buf = b""
+                                while True:
+                                    chunk = client_socket.recv(4096)
+                                    if not chunk:
+                                        response = "ERROR Connection lost while reading zip data"
+                                        client_socket.sendall((response + '\n').encode('utf-8'))
+                                        break
+                                    upload_buf += chunk
+                                    while b"\n" in upload_buf:
+                                        line_bytes, upload_buf = upload_buf.split(b"\n", 1)
+                                        line = line_bytes.decode('utf-8').strip()
+                                        if line == "END_UPLOAD":
+                                            zip_bytes = base64.b64decode(''.join(b64_lines))
+                                            count = self.file_manager.import_recordings(zip_bytes)
+                                            response = f"OK Imported {count} files"
+                                            client_socket.sendall((response + '\n').encode('utf-8'))
+                                            print(response)
+                                            upload_done = True
+                                            break
+                                        if line:
+                                            b64_lines.append(line)
+                                    if upload_done:
+                                        break
+                            except ValueError as e:
+                                response = f"ERROR {e}"
+                                client_socket.sendall((response + '\n').encode('utf-8'))
+                                print(response)
+                            except Exception as e:
+                                response = f"ERROR {e}"
+                                client_socket.sendall((response + '\n').encode('utf-8'))
+                                print(response)
+                            continue
+
                         # ===== END TIMELINE COMMANDS =====
                     client_socket.close()
                 except Exception as e:
@@ -1712,6 +1754,21 @@ class PumpkinFace:
                         audio_bytes = base64.b64decode(parts[2])
                         self.file_manager.upload_audio(filename, audio_bytes)
                         await websocket.send(f"OK Uploaded {filename}")
+                        continue
+                    if message.startswith("import_recordings "):
+                        import base64
+                        parts = message.split(maxsplit=1)
+                        if len(parts) < 2:
+                            await websocket.send("ERROR import_recordings requires: import_recordings <base64-zip>")
+                            continue
+                        try:
+                            zip_bytes = base64.b64decode(parts[1])
+                            count = self.file_manager.import_recordings(zip_bytes)
+                            await websocket.send(f"OK Imported {count} files")
+                        except ValueError as e:
+                            await websocket.send(f"ERROR {e}")
+                        except Exception as e:
+                            await websocket.send(f"ERROR {e}")
                         continue
                     response = self.command_router.execute(message)
                     if response:  # Only send response if non-empty

--- a/tests/test_export_import_recordings.py
+++ b/tests/test_export_import_recordings.py
@@ -1,0 +1,348 @@
+"""
+Export/Import Recordings Tests — Issue #88
+
+Tests for FileManager.export_recordings() and FileManager.import_recordings(),
+covering:
+  1. Export — produces a valid zip containing all .json and audio files
+  2. Export — returns an empty (but valid) zip when the recordings dir is absent
+  3. Import — extracts files and overwrites existing ones
+  4. Import — ignores files with unsupported extensions
+  5. Import — strips directory components from zip entry names
+  6. Import — raises ValueError on bad zip data
+  7. Import — raises ValueError when zip has no valid files
+  8. CommandRouter.execute("export_recordings") — returns RECORDINGS_ZIP: prefix
+  9. CommandRouter.execute("import_recordings") — returns IMPORT_RECORDINGS_MODE
+ 10. client_example.export_recordings / import_recordings — happy paths
+
+Author: Mylo (Tester)
+Date: 2026-03-20
+"""
+
+import base64
+import io
+import json
+import os
+import sys
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from timeline import FileManager, Timeline
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_minimal_timeline_json() -> str:
+    """Return a minimal valid Timeline JSON string."""
+    tl = Timeline()
+    return json.dumps(tl.to_dict())
+
+
+def _zip_containing(files: dict) -> bytes:
+    """Build a zip in memory from a {name: bytes} dict and return raw bytes."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        for name, data in files.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# FileManager.export_recordings()
+# ---------------------------------------------------------------------------
+
+class TestExportRecordings:
+    def test_export_empty_dir_returns_valid_empty_zip(self, tmp_path):
+        fm = FileManager(recordings_dir=tmp_path)
+        raw = fm.export_recordings()
+        buf = io.BytesIO(raw)
+        with zipfile.ZipFile(buf, 'r') as zf:
+            assert zf.namelist() == []
+
+    def test_export_nonexistent_dir_returns_valid_empty_zip(self, tmp_path):
+        fm = FileManager(recordings_dir=tmp_path / "missing")
+        raw = fm.export_recordings()
+        buf = io.BytesIO(raw)
+        with zipfile.ZipFile(buf, 'r') as zf:
+            assert zf.namelist() == []
+
+    def test_export_includes_json_files(self, tmp_path):
+        (tmp_path / "session1.json").write_text(_make_minimal_timeline_json())
+        (tmp_path / "session2.json").write_text(_make_minimal_timeline_json())
+        fm = FileManager(recordings_dir=tmp_path)
+        raw = fm.export_recordings()
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            names = zf.namelist()
+        assert "session1.json" in names
+        assert "session2.json" in names
+
+    def test_export_includes_audio_files(self, tmp_path):
+        audio_exts = ('.mp3', '.wav', '.ogg', '.m4a', '.aac', '.flac')
+        for ext in audio_exts:
+            (tmp_path / f"track{ext}").write_bytes(b"fake audio")
+        fm = FileManager(recordings_dir=tmp_path)
+        raw = fm.export_recordings()
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            names = zf.namelist()
+        for ext in audio_exts:
+            assert f"track{ext}" in names
+
+    def test_export_excludes_unsupported_files(self, tmp_path):
+        (tmp_path / "readme.txt").write_text("notes")
+        (tmp_path / "session1.json").write_text(_make_minimal_timeline_json())
+        fm = FileManager(recordings_dir=tmp_path)
+        raw = fm.export_recordings()
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            names = zf.namelist()
+        assert "readme.txt" not in names
+        assert "session1.json" in names
+
+    def test_export_returns_bytes(self, tmp_path):
+        fm = FileManager(recordings_dir=tmp_path)
+        raw = fm.export_recordings()
+        assert isinstance(raw, bytes)
+
+    def test_export_zip_entries_use_basenames_only(self, tmp_path):
+        (tmp_path / "my_session.json").write_text(_make_minimal_timeline_json())
+        fm = FileManager(recordings_dir=tmp_path)
+        raw = fm.export_recordings()
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            for name in zf.namelist():
+                assert '/' not in name, f"Entry should not contain path separator: {name}"
+
+
+# ---------------------------------------------------------------------------
+# FileManager.import_recordings()
+# ---------------------------------------------------------------------------
+
+class TestImportRecordings:
+    def test_import_json_files(self, tmp_path):
+        content = _make_minimal_timeline_json()
+        raw_zip = _zip_containing({"session1.json": content.encode()})
+        fm = FileManager(recordings_dir=tmp_path)
+        count = fm.import_recordings(raw_zip)
+        assert count == 1
+        assert (tmp_path / "session1.json").read_text() == content
+
+    def test_import_audio_files(self, tmp_path):
+        raw_zip = _zip_containing({"track.mp3": b"fake mp3 data"})
+        fm = FileManager(recordings_dir=tmp_path)
+        count = fm.import_recordings(raw_zip)
+        assert count == 1
+        assert (tmp_path / "track.mp3").read_bytes() == b"fake mp3 data"
+
+    def test_import_overwrites_existing_files(self, tmp_path):
+        (tmp_path / "session1.json").write_text("old content")
+        new_content = _make_minimal_timeline_json().encode()
+        raw_zip = _zip_containing({"session1.json": new_content})
+        fm = FileManager(recordings_dir=tmp_path)
+        fm.import_recordings(raw_zip)
+        assert (tmp_path / "session1.json").read_bytes() == new_content
+
+    def test_import_creates_recordings_dir_if_missing(self, tmp_path):
+        dest = tmp_path / "recordings"
+        raw_zip = _zip_containing({"session1.json": _make_minimal_timeline_json().encode()})
+        fm = FileManager(recordings_dir=dest)
+        fm.import_recordings(raw_zip)
+        assert dest.exists()
+
+    def test_import_ignores_unsupported_extensions(self, tmp_path):
+        raw_zip = _zip_containing({
+            "session1.json": _make_minimal_timeline_json().encode(),
+            "readme.txt": b"notes",
+        })
+        fm = FileManager(recordings_dir=tmp_path)
+        count = fm.import_recordings(raw_zip)
+        assert count == 1
+        assert not (tmp_path / "readme.txt").exists()
+
+    def test_import_strips_directory_components(self, tmp_path):
+        raw_zip = _zip_containing({"subdir/session1.json": _make_minimal_timeline_json().encode()})
+        fm = FileManager(recordings_dir=tmp_path)
+        count = fm.import_recordings(raw_zip)
+        assert count == 1
+        assert (tmp_path / "session1.json").exists()
+
+    def test_import_returns_count_of_extracted_files(self, tmp_path):
+        raw_zip = _zip_containing({
+            "a.json": _make_minimal_timeline_json().encode(),
+            "b.json": _make_minimal_timeline_json().encode(),
+            "c.mp3": b"audio",
+        })
+        fm = FileManager(recordings_dir=tmp_path)
+        count = fm.import_recordings(raw_zip)
+        assert count == 3
+
+    def test_import_raises_on_invalid_zip(self, tmp_path):
+        fm = FileManager(recordings_dir=tmp_path)
+        with pytest.raises(ValueError, match="Invalid zip file"):
+            fm.import_recordings(b"this is not a zip")
+
+    def test_import_raises_when_no_valid_files_in_zip(self, tmp_path):
+        raw_zip = _zip_containing({"readme.txt": b"nothing here"})
+        fm = FileManager(recordings_dir=tmp_path)
+        with pytest.raises(ValueError, match="no valid recording or audio files"):
+            fm.import_recordings(raw_zip)
+
+    def test_import_all_audio_extensions(self, tmp_path):
+        audio_exts = ('.mp3', '.wav', '.ogg', '.m4a', '.aac', '.flac')
+        files = {f"track{ext}": b"fake" for ext in audio_exts}
+        raw_zip = _zip_containing(files)
+        fm = FileManager(recordings_dir=tmp_path)
+        count = fm.import_recordings(raw_zip)
+        assert count == len(audio_exts)
+
+
+# ---------------------------------------------------------------------------
+# CommandRouter — export_recordings and import_recordings commands
+# ---------------------------------------------------------------------------
+
+class TestCommandRouterExportImport:
+    def _make_router(self, tmp_path):
+        """Build a minimal CommandRouter with mocked pumpkin and real FileManager."""
+        from command_handler import CommandRouter
+
+        pumpkin = MagicMock()
+        # Wire recording_session and timeline_playback so the router doesn't crash
+        pumpkin.recording_session.is_recording = False
+        pumpkin.timeline_playback.state.value = "stopped"
+        pumpkin.timeline_playback.filename = None
+        # Use a real FileManager pointing at tmp_path
+        from timeline import FileManager
+        fm = FileManager(recordings_dir=tmp_path)
+        pumpkin.file_manager = fm
+
+        # expression class that always raises (so expression commands fail cleanly)
+        class FakeExpr:
+            def __init__(self, val):
+                raise ValueError(f"unknown: {val}")
+
+        return CommandRouter(pumpkin, FakeExpr)
+
+    def test_export_recordings_returns_recordings_zip_prefix(self, tmp_path):
+        router = self._make_router(tmp_path)
+        response = router.execute("export_recordings")
+        assert response.startswith("RECORDINGS_ZIP:")
+
+    def test_export_recordings_base64_decodes_to_valid_zip(self, tmp_path):
+        (tmp_path / "session1.json").write_text(_make_minimal_timeline_json())
+        router = self._make_router(tmp_path)
+        response = router.execute("export_recordings")
+        b64 = response[len("RECORDINGS_ZIP:"):]
+        raw = base64.b64decode(b64)
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            assert "session1.json" in zf.namelist()
+
+    def test_export_recordings_empty_dir_returns_empty_zip(self, tmp_path):
+        router = self._make_router(tmp_path)
+        response = router.execute("export_recordings")
+        assert response.startswith("RECORDINGS_ZIP:")
+        raw = base64.b64decode(response[len("RECORDINGS_ZIP:"):])
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            assert zf.namelist() == []
+
+    def test_import_recordings_returns_import_mode_marker(self, tmp_path):
+        router = self._make_router(tmp_path)
+        response = router.execute("import_recordings")
+        assert response == "IMPORT_RECORDINGS_MODE"
+
+
+# ---------------------------------------------------------------------------
+# client_example — export_recordings / import_recordings
+# ---------------------------------------------------------------------------
+
+import client_example
+
+
+class TestClientExportRecordings:
+    def _make_socket(self, response_bytes: bytes):
+        mock_sock = MagicMock()
+        # Simulate server sending response then closing connection
+        mock_sock.recv.side_effect = [response_bytes, b'']
+        return mock_sock
+
+    def test_export_recordings_saves_zip_to_disk(self, tmp_path):
+        content = _make_minimal_timeline_json().encode()
+        raw_zip = _zip_containing({"session1.json": content})
+        b64 = base64.b64encode(raw_zip).decode('ascii')
+        server_response = (f"RECORDINGS_ZIP:{b64}\n").encode('utf-8')
+
+        output_path = str(tmp_path / "out.zip")
+        with patch('socket.socket') as mock_sock_cls:
+            mock_instance = self._make_socket(server_response)
+            mock_sock_cls.return_value = mock_instance
+            client_example.export_recordings(output_path)
+
+        assert os.path.exists(output_path)
+        with zipfile.ZipFile(output_path) as zf:
+            assert "session1.json" in zf.namelist()
+
+    def test_export_recordings_handles_server_error(self, tmp_path, capsys):
+        server_response = b"ERROR No recordings found\n"
+        output_path = str(tmp_path / "out.zip")
+        with patch('socket.socket') as mock_sock_cls:
+            mock_instance = self._make_socket(server_response)
+            mock_sock_cls.return_value = mock_instance
+            client_example.export_recordings(output_path)
+
+        captured = capsys.readouterr()
+        assert "Error" in captured.out
+        assert not os.path.exists(output_path)
+
+    def test_export_recordings_handles_connection_error(self, tmp_path, capsys):
+        output_path = str(tmp_path / "out.zip")
+        with patch('socket.socket') as mock_sock_cls:
+            mock_instance = MagicMock()
+            mock_instance.connect.side_effect = ConnectionRefusedError("refused")
+            mock_sock_cls.return_value = mock_instance
+            client_example.export_recordings(output_path)
+
+        captured = capsys.readouterr()
+        assert "Error" in captured.out
+
+
+class TestClientImportRecordings:
+    def test_import_recordings_sends_zip_to_server(self, tmp_path):
+        content = _make_minimal_timeline_json().encode()
+        raw_zip = _zip_containing({"session1.json": content})
+        zip_path = str(tmp_path / "bundle.zip")
+        with open(zip_path, 'wb') as f:
+            f.write(raw_zip)
+
+        with patch('socket.socket') as mock_sock_cls:
+            mock_instance = MagicMock()
+            mock_instance.recv.return_value = b'READY'
+            mock_sock_cls.return_value = mock_instance
+            # Second recv (final response)
+            mock_instance.recv.side_effect = [b'READY', b'OK Imported 1 files']
+            client_example.import_recordings(zip_path)
+
+        mock_instance.connect.assert_called_once_with(('localhost', 5000))
+        # Verify END_UPLOAD was sent
+        sent_calls = [c[0][0] for c in mock_instance.send.call_args_list]
+        assert b"END_UPLOAD\n" in sent_calls
+
+    def test_import_recordings_file_not_found(self, tmp_path, capsys):
+        client_example.import_recordings(str(tmp_path / "nonexistent.zip"))
+        captured = capsys.readouterr()
+        assert "Error" in captured.out
+
+    def test_import_recordings_handles_connection_error(self, tmp_path, capsys):
+        zip_path = str(tmp_path / "bundle.zip")
+        with open(zip_path, 'wb') as f:
+            f.write(_zip_containing({"a.json": b"{}"}))
+
+        with patch('socket.socket') as mock_sock_cls:
+            mock_instance = MagicMock()
+            mock_instance.connect.side_effect = ConnectionRefusedError("refused")
+            mock_sock_cls.return_value = mock_instance
+            client_example.import_recordings(zip_path)
+
+        captured = capsys.readouterr()
+        assert "Error" in captured.out

--- a/timeline.py
+++ b/timeline.py
@@ -16,9 +16,11 @@ Design decisions:
 - Invalid commands during playback stop gracefully
 """
 
+import io
 import json
 import os
 import time
+import zipfile
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -800,3 +802,67 @@ class FileManager:
             raise FileExistsError(f"Recording already exists: {new_name}")
         
         old_path.rename(new_path)
+
+    def export_recordings(self) -> bytes:
+        """Export all recordings and audio files as a zip archive.
+
+        Returns:
+            Raw zip file bytes (empty zip if recordings directory does not exist)
+        """
+        audio_extensions = ('.mp3', '.wav', '.ogg', '.m4a', '.aac', '.flac')
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w', zipfile.ZIP_DEFLATED) as zf:
+            if self.recordings_dir.exists():
+                for filepath in self.recordings_dir.glob('*.json'):
+                    zf.write(filepath, filepath.name)
+                for ext in audio_extensions:
+                    for filepath in self.recordings_dir.glob(f'*{ext}'):
+                        zf.write(filepath, filepath.name)
+        return buf.getvalue()
+
+    def import_recordings(self, zip_bytes: bytes) -> int:
+        """Import recordings and audio files from a zip archive.
+
+        Files are extracted to the recordings directory. Existing files are
+        overwritten. Only ``.json`` and audio files are extracted; directory
+        paths within the zip are stripped to the basename.
+
+        Args:
+            zip_bytes: Raw zip file bytes
+
+        Returns:
+            Number of files imported
+
+        Raises:
+            ValueError: If the zip is invalid or contains no valid files
+        """
+        audio_extensions = ('.mp3', '.wav', '.ogg', '.m4a', '.aac', '.flac')
+        allowed_extensions = ('.json',) + audio_extensions
+
+        try:
+            buf = io.BytesIO(zip_bytes)
+            with zipfile.ZipFile(buf, 'r') as zf:
+                valid_entries = [
+                    name for name in zf.namelist()
+                    if not name.endswith('/')  # skip directory entries
+                    and any(Path(name).name.lower().endswith(ext) for ext in allowed_extensions)
+                ]
+
+                if not valid_entries:
+                    raise ValueError("Zip contains no valid recording or audio files")
+
+                self.recordings_dir.mkdir(parents=True, exist_ok=True)
+
+                count = 0
+                for name in valid_entries:
+                    basename = Path(name).name
+                    if not basename:
+                        continue
+                    dest = self.recordings_dir / basename
+                    dest.write_bytes(zf.read(name))
+                    count += 1
+
+                return count
+        except zipfile.BadZipFile:
+            raise ValueError("Invalid zip file")


### PR DESCRIPTION
## Summary
Implements xport_recordings and import_recordings commands from issue #88.

### Export
- xport_recordings command zips all .json and audio files from the recordings directory, returns RECORDINGS_ZIP:<base64>
- Client: xport_recordings <output_zip> saves the zip locally

### Import
- import_recordings command accepts a zip and extracts it to the recordings directory (overwrites existing)
- **TCP**: multi-step protocol (server sends READY → client sends base64-encoded zip → client sends END_UPLOAD)
- **WebSocket**: inline format import_recordings <base64-zip>
- Client: import_recordings <zip_file> uploads the zip

### Tests
- 27 new tests in 	ests/test_export_import_recordings.py covering all new functionality
- All 27 pass; no regressions to existing tests

Closes #88